### PR TITLE
Add XYZ field filter and pcl merge topics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(${PROJECT_NAME}
         src/pointcloud_merger.cpp
         src/passthrough_filter.cpp
         src/voxel_filter.cpp
+        src/pointcloud_filter_xyz.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/include/pointcloud_merger/passthrough_filter.h
+++ b/include/pointcloud_merger/passthrough_filter.h
@@ -21,4 +21,4 @@ namespace pointcloud_merger {
       pcl::PassThrough<pcl::PCLPointCloud2> impl_;
     };
 
-}  // namespace passthrough_filter
+}  // namespace pointcloud_merger

--- a/include/pointcloud_merger/pointcloud_filter_xyz.h
+++ b/include/pointcloud_merger/pointcloud_filter_xyz.h
@@ -1,0 +1,30 @@
+// Only keeps the XYZ fields of the pointcloud and drops the rest
+
+#pragma once
+
+#include <nodelet/nodelet.h>
+#include <ros/ros.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+namespace pointcloud_merger
+{
+
+class PointCloudXYZFilterNodelet : public nodelet::Nodelet
+{
+public:
+    PointCloudXYZFilterNodelet() = default;
+
+private:
+    virtual void onInit() override;
+    void pointcloudCallback(const sensor_msgs::PointCloud2ConstPtr& msg);
+
+    ros::NodeHandle nh_;
+    ros::NodeHandle private_nh_;
+    ros::Subscriber sub_;
+    ros::Publisher pub_;
+};
+
+} // namespace pointcloud_merger

--- a/include/pointcloud_merger/pointcloud_merger.h
+++ b/include/pointcloud_merger/pointcloud_merger.h
@@ -61,4 +61,4 @@ namespace pointcloud_merger {
       boost::mutex data_mutex_;
     };
 
-}  // namespace pointcloud_filters
+}  // namespace pointcloud_merger

--- a/launch/inference_merge_clouds.launch
+++ b/launch/inference_merge_clouds.launch
@@ -1,0 +1,36 @@
+<launch>
+  <!--  Parameters-->
+  <arg name="cloud_out" default="/merged_pointcloud"/>
+  <arg name="use_gdb" default="false"/>
+  <arg name="launch_prefix" value="xterm -e gdb --args" if="$(arg use_gdb)"/>
+  <arg name="launch_prefix" value="" unless="$(arg use_gdb)"/>
+
+  <arg name="nodelet_manager" default="nodelet_manager"/>
+  <arg name="nodelet_args" default="--no-bond"/>
+  <arg name="respawn" default="false"/>
+  <arg name="simulation" default="false"/>
+
+  <node pkg="nodelet"
+          type="nodelet"
+          name="$(arg nodelet_manager)"
+          launch-prefix="$(arg launch_prefix)"
+          args="manager"
+          output="screen"
+          respawn="$(arg respawn)"/>
+
+ <node pkg="nodelet" 
+        type="nodelet" 
+        name="merge_clouds" 
+        args="load pcl/PointCloudConcatenateDataSynchronizer $(arg nodelet_manager) $(arg nodelet_args)"
+        respawn="$(arg respawn)">
+    <remap from="~output" to="$(arg cloud_out)"/>
+    <rosparam>
+        approximate_sync: true
+        queue_size: 10
+        output_frame: base
+        input_topics:
+            - /pointcloud_out_0
+            - /pointcloud_out_1
+    </rosparam>
+  </node>
+</launch>

--- a/launch/replay_multiple/pointcloud_merge_crop_voxelize1.launch
+++ b/launch/replay_multiple/pointcloud_merge_crop_voxelize1.launch
@@ -105,16 +105,20 @@
               args="load pointcloud_merger/VoxelFilter $(arg nodelet_manager) $(arg nodelet_args)"
               respawn="$(arg respawn)">
         <remap from="~input" to="passthrough_filter_3_$(arg instance)/output"/>
-        <remap from="~output" to="$(arg cloud_out)"/>
+        <remap from="~output" to="xyz_filter_$(arg instance)/output"/>
 
         <rosparam>
           voxel_size: 0.04
         </rosparam>
       </node>
-
-  <node pkg="rostopic"
-        type="rostopic"
-        name="subscriber"
-        args="hz $(arg cloud_out)"
-        output="screen"/>
+<!-- Keep only XYZ fields -->
+      <node pkg="nodelet"
+              type="nodelet"
+              name="xyz_filter_$(arg instance)"
+              args="load pointcloud_merger/PointCloudXYZFilterNodelet $(arg nodelet_manager) $(arg nodelet_args)"
+              respawn="$(arg respawn)">
+        <param name="input_topic" value="xyz_filter_$(arg instance)/output" />
+        <param name="output_topic" value="$(arg cloud_out)" />
+      </node>
+      
 </launch>

--- a/launch/replay_multiple/pointcloud_merge_crop_voxelize2.launch
+++ b/launch/replay_multiple/pointcloud_merge_crop_voxelize2.launch
@@ -101,16 +101,20 @@
               args="load pointcloud_merger/VoxelFilter $(arg nodelet_manager) $(arg nodelet_args)"
               respawn="$(arg respawn)">
         <remap from="~input" to="passthrough_filter_3_$(arg instance)/output"/>
-        <remap from="~output" to="$(arg cloud_out)"/>
+        <remap from="~output" to="xyz_filter_$(arg instance)/output"/>
 
         <rosparam>
           voxel_size: 0.04
         </rosparam>
       </node>
+<!-- Keep only XYZ fields -->
+      <node pkg="nodelet"
+              type="nodelet"
+              name="xyz_filter_$(arg instance)"
+              args="load pointcloud_merger/PointCloudXYZFilterNodelet $(arg nodelet_manager) $(arg nodelet_args)"
+              respawn="$(arg respawn)">
+        <param name="input_topic" value="xyz_filter_$(arg instance)/output" />
+        <param name="output_topic" value="$(arg cloud_out)" />
+      </node>
 
-  <node pkg="rostopic"
-        type="rostopic"
-        name="subscriber"
-        args="hz $(arg cloud_out)"
-        output="screen"/>
 </launch>

--- a/pcl_ros_plugins.xml
+++ b/pcl_ros_plugins.xml
@@ -14,4 +14,7 @@
        base_class_type="nodelet::Nodelet">
     <description>Voxelizes a pointcloud</description>
   </class>
+  <class name="pointcloud_merger/PointCloudXYZFilterNodelet" type="pointcloud_merger::PointCloudXYZFilterNodelet" base_class_type="nodelet::Nodelet">
+    <description>PointCloud XYZ Filter Nodelet</description>
+  </class>
 </library>

--- a/src/pointcloud_filter_xyz.cpp
+++ b/src/pointcloud_filter_xyz.cpp
@@ -1,0 +1,39 @@
+#include "pointcloud_merger/pointcloud_filter_xyz.h"
+#include <pluginlib/class_list_macros.h>
+
+namespace pointcloud_merger
+{
+
+void PointCloudXYZFilterNodelet::onInit()
+{
+    nh_ = getNodeHandle();
+    private_nh_ = getPrivateNodeHandle();
+
+    // Get input and output topics from parameter server
+    std::string input_topic, output_topic;
+    private_nh_.getParam("input_topic", input_topic);
+    private_nh_.getParam("output_topic", output_topic);
+
+    // Initialize subscriber and publisher
+    sub_ = nh_.subscribe(input_topic, 1, &PointCloudXYZFilterNodelet::pointcloudCallback, this);
+    pub_ = nh_.advertise<sensor_msgs::PointCloud2>(output_topic, 1);
+}
+
+void PointCloudXYZFilterNodelet::pointcloudCallback(const sensor_msgs::PointCloud2ConstPtr& msg)
+{
+    // Convert ROS PointCloud2 to PCL PointCloud
+    pcl::PointCloud<pcl::PointXYZ> pcl_cloud;
+    pcl::fromROSMsg(*msg, pcl_cloud);
+
+    // Convert PCL PointCloud to ROS PointCloud2
+    sensor_msgs::PointCloud2 output;
+    pcl::toROSMsg(pcl_cloud, output);
+    output.header = msg->header;
+
+    // Publish filtered point cloud
+    pub_.publish(output);
+}
+
+} // namespace pointcloud_merger
+
+PLUGINLIB_EXPORT_CLASS(pointcloud_merger::PointCloudXYZFilterNodelet, nodelet::Nodelet)


### PR DESCRIPTION
Add a pcl filter which will drop all fields other than the XYZ. This is useful when we need to merge pointclouds with different fields. 
Add a launch file for merging clouds from different topics using the PointCloudConcatenateDataSynchronizer wrapper for PCL